### PR TITLE
feat: added subrouting support & any method support in router

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -360,6 +360,27 @@ export class Cpeak {
     }
   }
 
+  // Subroute
+  subroute(prefix: string, app: Cpeak) {
+    const cleanPrefix = prefix.endsWith("/*") ? prefix.slice(0, -2) : prefix;
+    const prefixLength = cleanPrefix === "/" ? 0 : cleanPrefix.length;
+
+    const wrapper = async (req: CpeakRequest, res: CpeakResponse) => {
+      const rawPath = req.url?.slice(prefixLength) || "/";
+      req.url = rawPath;
+      const qIndex = rawPath.indexOf("?");
+      const path = qIndex === -1 ? rawPath : rawPath.substring(0, qIndex);
+      await app.#runMiddleware(
+        req,
+        res,
+        app.#middleware,
+        0,
+        path
+      );
+    };
+    this.route("any", cleanPrefix+'/*', wrapper);
+  }
+
   route(method: string, path: string, ...args: (RouteMiddleware | Handler)[]) {
     // The last argument should always be our handler
     const cb = args.pop() as Handler;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -360,7 +360,14 @@ export class Cpeak {
     }
   }
 
-  // Subroute
+  /**
+   * Mounts a sub-router instance under a given path prefix.
+   *
+   * @param prefix - The base path prefix for the sub-router. If it ends with `/*`,
+   * it acts as a wildcard match for all nested subpaths. Without `/*`, it matches
+   * only the exact prefix path.
+   * @param app - The sub-router Cpeak instance to mount.
+   */
   subroute(prefix: string, app: Cpeak) {
     const cleanPrefix = prefix.endsWith("/*") ? prefix.slice(0, -2) : prefix;
     const prefixLength = cleanPrefix === "/" ? 0 : cleanPrefix.length;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -370,15 +370,9 @@ export class Cpeak {
       req.url = rawPath;
       const qIndex = rawPath.indexOf("?");
       const path = qIndex === -1 ? rawPath : rawPath.substring(0, qIndex);
-      await app.#runMiddleware(
-        req,
-        res,
-        app.#middleware,
-        0,
-        path
-      );
+      await app.#runMiddleware(req, res, app.#middleware, 0, path);
     };
-    this.route("any", cleanPrefix+'/*', wrapper);
+    this.route("any", prefix, wrapper);
   }
 
   route(method: string, path: string, ...args: (RouteMiddleware | Handler)[]) {

--- a/lib/internal/router.ts
+++ b/lib/internal/router.ts
@@ -142,11 +142,18 @@ export class Router {
   }
 
   find(method: string, path: string): RouteMatch | null {
-    const root = this.#treesByMethod.get(method.toLowerCase());
-    if (!root) return null;
-
     const segments = splitPath(path);
-    return matchSegments(root, segments, 0, []);
+
+    const root = this.#treesByMethod.get(method.toLowerCase());
+    if (root) {
+      const match = matchSegments(root, segments, 0, []);
+      if (match) return match;
+    }
+
+    const anyRoot = this.#treesByMethod.get("any");
+    if (!anyRoot) return null;
+
+    return matchSegments(anyRoot, segments, 0, []);
   }
 }
 

--- a/test/sub-router.test.ts
+++ b/test/sub-router.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert";
+import supertest from "supertest";
+import { Cpeak } from "../lib/";
+import type { CpeakRequest, CpeakResponse } from "../lib/types";
+
+const PORT = 7550;
+const r = supertest(`http://localhost:${PORT}`);
+
+describe("Subrouter", function () {
+  let app: Cpeak;
+
+  before(function (done) {
+    app = new Cpeak();
+
+    const users = new Cpeak();
+    users.route("get", "/", (req: CpeakRequest, res: CpeakResponse) =>
+      res.json({ r: "root" })
+    );
+    users.route("get", "/:id", (req: CpeakRequest, res: CpeakResponse) =>
+      res.json({ id: req.params.id })
+    );
+
+    const exact = new Cpeak();
+    exact.route("get", "/", (req: CpeakRequest, res: CpeakResponse) =>
+      res.json({ r: "exact" })
+    );
+
+    app.subroute("/api/users/*", users);
+    app.subroute("/api/v2", exact);
+
+    app.listen(PORT, done);
+  });
+
+  after(function (done) {
+    app.close(done);
+  });
+
+  it("routes to subrouter root", async () => {
+    const res = await r.get("/api/users/");
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(res.body, { r: "root" });
+  });
+
+  it("strips prefix and matches :id param", async () => {
+    const res = await r.get("/api/users/42");
+    assert.deepStrictEqual(res.body, { id: "42" });
+  });
+
+  it("exact prefix (no /*) matches only the exact path", async () => {
+    assert.strictEqual((await r.get("/api/v2")).status, 200);
+    assert.strictEqual((await r.get("/api/v2/items")).status, 404);
+  });
+});
+
+describe("Subroute Middl test", () => {
+  let app: Cpeak;
+  let count = 0;
+  const r2 = supertest(`http://localhost:${PORT + 1}`);
+
+  before((done) => {
+    app = new Cpeak();
+
+    app.beforeEach((req, res, next) => {
+      count++;
+      next();
+    });
+    app.route("get", "/", (_, res) => res.end("/"));
+
+    const userRoute = new Cpeak();
+    userRoute.beforeEach((req, res, next) => {
+      count++;
+      next();
+    });
+    userRoute.route("get", "/", (_, res) => res.end("/user"));
+
+    app.subroute("/user/*", userRoute);
+    app.listen(PORT + 1, done);
+  });
+
+  after((done) => {
+    app.close(done);
+  });
+
+  it("global middleware runs but subrouter middleware doesn't for parent routes", async () => {
+    count = 0;
+    await r2.get("/");
+    assert.strictEqual(count, 1);
+  });
+
+  it("both global and subrouter middleware run for subrouted paths", async () => {
+    count = 0;
+    await r2.get("/user/");
+    assert.strictEqual(count, 2);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- Adds `any` method supports in router , so now user can do `app.route('any', "/route", () =>{} )` and it will match any incoming method.
- Adds Support of Sub-Routing. now user can do subrouting easily like
   - `
   const app = new Cpeak()
   const userRouter = new Cpeak()
   app.subroute("/api/user/*", userRouter)
   `
now any incoming req to path `/api/user` will go to `userRouter`

- added some test cases for sub-route